### PR TITLE
Add API version to Sanity client

### DIFF
--- a/utils/sanity/api.ts
+++ b/utils/sanity/api.ts
@@ -13,6 +13,7 @@ import {
 const client = sanityClient({
   projectId: process.env.SANITY_PROJECT_ID as string,
   dataset: process.env.SANITY_DATASET as string,
+  apiVersion: '2021-08-31',
   useCdn: process.env.NODE_ENV === 'production', // `false` if you want to ensure fresh data
 })
 


### PR DESCRIPTION
When running a dev environment Sanity warns:

> Using the Sanity client without specifying an API version is deprecated. See [https://docs.sanity.io/help/js-client-api-version](https://docs.sanity.io/help/js-client-api-version)

This fixes that!